### PR TITLE
Corrects how localStorage could be used

### DIFF
--- a/projects/lib/src/oauth-service.ts
+++ b/projects/lib/src/oauth-service.ts
@@ -354,7 +354,9 @@ export class OAuthService extends AuthConfig {
     /**
      * DEPRECATED. Use a provider for OAuthStorage instead:
      *
-     * { provide: OAuthStorage, useValue: localStorage }
+     * 
+     * { provide: OAuthStorage, useFactory: oAuthStorageFactory }
+     * export function oAuthStorageFactory(): OAuthStorage { return localStorage; }
      *
      * Sets a custom storage used to store the received
      * tokens on client side. By default, the browser's


### PR DESCRIPTION
You can not provide `localStorage` directly via `useValue`, you need to have a factory for that.